### PR TITLE
A recent ENUM bug fix in 3.1 won't allow for this syntax anymore.

### DIFF
--- a/addons/codeandweb.texturepacker/texturepacker_import_spritesheet.gd
+++ b/addons/codeandweb.texturepacker/texturepacker_import_spritesheet.gd
@@ -55,7 +55,7 @@ func get_preset_count():
 
 func get_preset_name(preset):
 	match preset:
-		PRESET_DEFAULT: return "Default"
+		Preset.PRESET_DEFAULT: return "Default"
 
 
 func get_import_options(preset):

--- a/addons/codeandweb.texturepacker/texturepacker_import_tileset.gd
+++ b/addons/codeandweb.texturepacker/texturepacker_import_tileset.gd
@@ -55,7 +55,7 @@ func get_preset_count():
 
 func get_preset_name(preset):
 	match preset:
-		PRESET_DEFAULT: return "Default"
+		Preset.PRESET_DEFAULT: return "Default"
 
 
 func get_import_options(preset):


### PR DESCRIPTION
In upcoming version of 3.1 the add-on will break because of this fix to enum constants: https://github.com/godotengine/godot/pull/23648

The syntax will have to use the full notation.