### PR TITLE
Free both of the imageLoader instances and stop leaks

### DIFF
--- a/addons/codeandweb.texturepacker/texturepacker_import_spritesheet.gd
+++ b/addons/codeandweb.texturepacker/texturepacker_import_spritesheet.gd
@@ -23,11 +23,15 @@
 tool
 extends EditorImportPlugin
 
-var imageLoader = preload("image_loader.gd").new();
+var imageLoader = preload("image_loader.gd").new()
 
 enum Preset { PRESET_DEFAULT }
 
 # const TiledMapReader = preload("tiled_map_reader.gd")
+
+func _notification(what):
+	if what == NOTIFICATION_PREDELETE:
+		imageLoader.free()
 
 func get_importer_name():
 	return "codeandweb.texturepacker_import_spritesheet"

--- a/addons/codeandweb.texturepacker/texturepacker_import_tileset.gd
+++ b/addons/codeandweb.texturepacker/texturepacker_import_tileset.gd
@@ -23,11 +23,15 @@
 tool
 extends EditorImportPlugin
 
-var imageLoader = preload("image_loader.gd").new();
+var imageLoader = preload("image_loader.gd").new()
 
 enum Preset { PRESET_DEFAULT }
 
 # const TiledMapReader = preload("tiled_map_reader.gd")
+
+func _notification(what):
+	if what == NOTIFICATION_PREDELETE:
+		imageLoader.free()
 
 func get_importer_name():
 	return "codeandweb.texturepacker_import_tileset"


### PR DESCRIPTION
This fixes the imageLoader from being a leaked instance when exporting from the command line.